### PR TITLE
Add verbose argument to initialize call

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Afterwards you can initialize Appodeal with the function:
 await Appodeal.initialize(
   hasConsent: true,
   adTypes: [AdType.BANNER, AdType.INTERSTITIAL, AdType.REWARD],
-  testMode: true
+  testMode: true,
+  verbose: true,
 );
 
 // At this point you are ready to display ads
@@ -72,6 +73,8 @@ await Appodeal.initialize(
 * `adTypes` (optional) you must set a list (of type `AdType`) with all the ad types that you would like to display in your app. If this parameter is undefined or an empty list then no ads will be loaded.
 
 * `testMode` (optional) you must set `false` (default) or `true` depending if you are running the ads during development/test or production.
+
+* `verbose` (optional) set this to `true` if you want Appodeal's verbose logs to be visible amongst the Flutter logs. Default is `false`.
 
 ## 👮🏾‍♂️ Consent to track the user
 

--- a/android/src/main/kotlin/io/vinicius/appodeal_flutter/AppodealFlutterPlugin.kt
+++ b/android/src/main/kotlin/io/vinicius/appodeal_flutter/AppodealFlutterPlugin.kt
@@ -3,6 +3,7 @@ package io.vinicius.appodeal_flutter
 import android.app.Activity
 import androidx.annotation.NonNull
 import com.appodeal.ads.Appodeal
+import com.appodeal.ads.utils.Log
 import com.explorestack.consent.Consent
 import com.explorestack.consent.Consent.ShouldShow
 import com.explorestack.consent.ConsentForm
@@ -76,6 +77,7 @@ class AppodealFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         val hasConsent = args["hasConsent"] as Boolean
         val adTypes = args["adTypes"] as List<Int>
         val testMode = args["testMode"] as Boolean
+        val verbose = args["verbose"] as Boolean
 
         // Registering callbacks
         setCallbacks()
@@ -83,6 +85,9 @@ class AppodealFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         val ads = adTypes.fold(0) { acc, value -> acc or getAdType(value) }
         Appodeal.setTesting(testMode)
         Appodeal.initialize(activity, appKey, ads, hasConsent)
+        if (verbose) {
+            Appodeal.setLogLevel(Log.LogLevel.verbose)
+        }
 
         result.success(null)
     }

--- a/ios/Classes/SwiftAppodealFlutterPlugin.swift
+++ b/ios/Classes/SwiftAppodealFlutterPlugin.swift
@@ -45,6 +45,7 @@ public class SwiftAppodealFlutterPlugin: NSObject, FlutterPlugin {
         let hasConsent = args["hasConsent"] as! Bool
         let adTypes = args["adTypes"] as! [Int]
         let testMode = args["testMode"] as! Bool
+        let verbose = args["verbose"] as! Bool
 
         // Registering callbacks
         setCallbacks()
@@ -52,6 +53,10 @@ public class SwiftAppodealFlutterPlugin: NSObject, FlutterPlugin {
         let ads = AppodealAdType(rawValue: adTypes.reduce(0) { $0 | getAdType(adId: $1).rawValue })
         Appodeal.setTestingEnabled(testMode)
         Appodeal.initialize(withApiKey: appKey, types: ads, hasConsent: hasConsent)
+
+        if verbose {
+            Appodeal.setLogLevel(APDLogLevel.verbose)
+        }
 
         result(nil)
     }

--- a/lib/src/appodeal.dart
+++ b/lib/src/appodeal.dart
@@ -31,7 +31,7 @@ class Appodeal {
   /// also if ads should be presented in test mode [testMode] or not. Always set test mode as `true` during development
   /// or tests.
   static Future<void> initialize(
-      {@required bool hasConsent, List<int> adTypes = const [], bool testMode = false}) async {
+      {@required bool hasConsent, List<int> adTypes = const [], bool testMode = false, bool verbose}) async {
     assert(_androidAppKey != null || _iosAppKey != null, 'You must set at least one of the keys for Android or iOS');
 
     // Register the callbacks
@@ -42,7 +42,8 @@ class Appodeal {
       'iosAppKey': _iosAppKey,
       'hasConsent': hasConsent,
       'adTypes': adTypes,
-      'testMode': testMode
+      'testMode': testMode,
+      'verbose': verbose,
     });
   }
 


### PR DESCRIPTION
I've added an optional `verbose` argument and documentation.

This just enables debug logging for the Appodeal SDK, which is invaluable in figuring out why ads aren't filling correctly.